### PR TITLE
Handle empty bytestrings in a stream

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -47,7 +47,6 @@ tests:
       - conduit-combinators
       - zstd
       - directory
-      - HUnit
-      - test-framework
-      - test-framework-hunit
-      - test-framework-th
+      - tasty
+      - tasty-quickcheck
+      - quickcheck-instances

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-12.10
+resolver: lts-15.7
 compiler-check: newer-minor
 
 


### PR DESCRIPTION
The existing implementation drops any data after an empty bytestring. Arguably this is unlikely input yet not impossible. This pull request adds a round trip property for random lists of bytestrings that fails without a fix for the underlying problem.